### PR TITLE
Fix no prevEl if moving to bottom.

### DIFF
--- a/lib/helper/summary-parser.coffee
+++ b/lib/helper/summary-parser.coffee
@@ -68,7 +68,7 @@ class SummaryParser
     # Check for children of new parent if index was passed
     if toWriteIndex > 0 and index
       prevEl = @tree[toWriteIndex - 1]
-      if prevEl.indent
+      if prevEl? and prevEl.indent
         toWrite.indent = prevEl.indent
       # Look for child elements until you don't find an indent
       while (nextEl = @tree[toWriteIndex])?


### PR DESCRIPTION
Should resolve #49, but brings up that there's no easy way to move an element _before_ another element, so it's a little clunky and you have to do some rearranging.
